### PR TITLE
Add support for :js_assets_paths configuration

### DIFF
--- a/lib/middleman-sprockets/extension.rb
+++ b/lib/middleman-sprockets/extension.rb
@@ -82,6 +82,11 @@ module Middleman::Sprockets
       # configure search paths
       append_path app.js_dir
       append_path app.css_dir
+
+      # add custom assets paths to the scope
+      app.js_assets_paths.each do |p|
+        append_path p
+      end
     end
 
     # Override Sprockets' default digest function to *not*


### PR DESCRIPTION
Hi Thomas, 

PR as requested.

Please Note! This addition depends upon code being present in middleman-core gem,  see [ https://github.com/kematzy/middleman/tree/add-js-external-assets-paths ]

Thanks for your time.
