### PR TITLE
adds helper to allow for improved script debugging

### DIFF
--- a/features/sprockets.feature
+++ b/features/sprockets.feature
@@ -20,6 +20,22 @@ Feature: Sprockets
     When I go to "/javascripts/multiple_engines.js"
     Then I should see "Hello One"
     
+  Scenario: Sprockets JS should only contain body when requested
+    Given the Server is running at "sprockets-app2"
+    When I go to "/javascripts/sprockets_base.js?body=1"
+    Then I should see "base"
+    And I should not see "sprockets_sub_function"
+    
+  Scenario: Script tags should be provided individually while debugging assets
+    Given the Server is running at "sprockets-app-debug-assets"
+    When I go to "/index.html"
+    Then I should see 
+      """
+      <script src="/javascripts/dependency2.js?body=1" type="text/javascript"></script>
+      <script src="/javascripts/dependency1.js?body=1" type="text/javascript"></script>
+      <script src="/javascripts/main.js?body=1" type="text/javascript"></script>
+      """
+    
   Scenario: Multiple engine files should build correctly
     Given a successfully built app at "sprockets-app2"
     When I cd to "build"

--- a/features/step_definitions/server_steps.rb
+++ b/features/step_definitions/server_steps.rb
@@ -1,0 +1,3 @@
+Then /^I should see$/ do |contents|
+  @browser.last_response.body.should include(contents)
+end

--- a/fixtures/sprockets-app-debug-assets/config.rb
+++ b/fixtures/sprockets-app-debug-assets/config.rb
@@ -1,0 +1,1 @@
+set :debug_assets, true

--- a/fixtures/sprockets-app-debug-assets/source/index.html.erb
+++ b/fixtures/sprockets-app-debug-assets/source/index.html.erb
@@ -1,0 +1,1 @@
+<%= javascript_include_tag "main" %>

--- a/fixtures/sprockets-app-debug-assets/source/javascripts/dependency1.js
+++ b/fixtures/sprockets-app-debug-assets/source/javascripts/dependency1.js
@@ -1,0 +1,3 @@
+//= require dependency2
+
+function dependency1() {}

--- a/fixtures/sprockets-app-debug-assets/source/javascripts/dependency2.js
+++ b/fixtures/sprockets-app-debug-assets/source/javascripts/dependency2.js
@@ -1,0 +1,1 @@
+function dependency2() {}

--- a/fixtures/sprockets-app-debug-assets/source/javascripts/main.js
+++ b/fixtures/sprockets-app-debug-assets/source/javascripts/main.js
@@ -1,0 +1,3 @@
+//= require dependency1
+
+function main() {}

--- a/lib/middleman-sprockets/extension.rb
+++ b/lib/middleman-sprockets/extension.rb
@@ -19,6 +19,10 @@ module Middleman::Sprockets
       require "middleman-sprockets/sass"
       app.register Middleman::Sprockets::Sass
 
+      app.after_configuration do
+        helpers JavascriptTagHelper
+      end
+
       # Once Middleman is setup
       app.ready do
         ::Tilt.register ::Sprockets::EjsTemplate, 'ejs'
@@ -122,5 +126,33 @@ module Middleman::Sprockets
 
     # Clear cache on error
     alias :css_exception_response :javascript_exception_response
+  end
+  
+  module JavascriptTagHelper
+    
+    # extend padrinos javascript_include_tag with debug functionality
+    # splits up script dependencies in individual files when
+    # configuration variable :debug_assets is set to true
+    def javascript_include_tag(*sources)
+      options = sources.extract_options!.symbolize_keys
+
+      if debug_assets
+
+        # loop through all sources and the dependencies and
+        # output each as script tag in the correct order
+        sources.map do |source|
+          dependencies_paths = sprockets[source].to_a.map do |dependency|
+            # if sprockets sees "?body=1" it only gives back the body
+            # of the script without the dependencies included
+            dependency.logical_path << "?body=1"
+          end
+
+          super(dependencies_paths)
+        end.join("")
+
+      else
+        super
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR adds a middleman helper that enables improved script debugging capabilities for middleman.

see issue https://github.com/middleman/middleman/issues/554
- When :debug_assets is set to true it renders each script as individual script tag in the correct order
- In production everything is like before

it uses the built in functionality of sprockets to receive only the script body by appending "?body=1" at the end of a request.

thanks for this awesome tool!
happy coding
