### PR TITLE
Do not always initialize with empty js_assets_paths

### DIFF
--- a/lib/middleman-sprockets/extension.rb
+++ b/lib/middleman-sprockets/extension.rb
@@ -8,11 +8,6 @@ module Middleman::Sprockets
 
     # Once registered
     def registered(app)
-      # Location of javascripts external to source directory.
-      # @return [Array]
-      #   set :js_assets_paths, ["#{root}/assets/javascripts/", "/path/2/external/js/repository/"]
-      app.set :js_assets_paths, []
-    
       # Add class methods to context
       app.send :include, InstanceMethods
       
@@ -93,8 +88,10 @@ module Middleman::Sprockets
       append_path app.css_dir
 
       # add custom assets paths to the scope
-      app.js_assets_paths.each do |p|
-        append_path p
+      if app.respond_to?(:js_assets_paths)
+        app.js_assets_paths.each do |p|
+          append_path p
+        end
       end
     end
 


### PR DESCRIPTION
Currently the js_assets_paths option get overwritten to []. 
