### PR TITLE
Update asset hashes for fix in asset hash extension.

### DIFF
--- a/features/asset_hash.feature
+++ b/features/asset_hash.feature
@@ -7,8 +7,8 @@ Feature: Assets get a file hash appended to their and references to them are upd
       | images/100px-1242c368.png |
       | images/100px-5fd6fb90.jpg |
       | images/100px-5fd6fb90.gif |
-      | javascripts/application-1d8d5276.js |
-      | stylesheets/site-50eaa978.css |
+      | javascripts/application-df677242.js |
+      | stylesheets/site-ed8c2d12.css |
       | index.html |
       | subdir/index.html |
       | other/index.html |
@@ -19,50 +19,50 @@ Feature: Assets get a file hash appended to their and references to them are upd
       | javascripts/application.js |
       | stylesheets/site.css |
       
-    And the file "javascripts/application-1d8d5276.js" should contain "img.src = '/images/100px-5fd6fb90.jpg'"
-    And the file "stylesheets/site-50eaa978.css" should contain "background-image: url('../images/100px-5fd6fb90.jpg')"
-    And the file "index.html" should contain 'href="stylesheets/site-50eaa978.css"'
-    And the file "index.html" should contain 'src="javascripts/application-1d8d5276.js"'
+    And the file "javascripts/application-df677242.js" should contain "img.src = '/images/100px-5fd6fb90.jpg'"
+    And the file "stylesheets/site-ed8c2d12.css" should contain "background-image: url('../images/100px-5fd6fb90.jpg')"
+    And the file "index.html" should contain 'href="stylesheets/site-ed8c2d12.css"'
+    And the file "index.html" should contain 'src="javascripts/application-df677242.js"'
     And the file "index.html" should contain 'src="images/100px-5fd6fb90.jpg"'
-    And the file "subdir/index.html" should contain 'href="../stylesheets/site-50eaa978.css"'
-    And the file "subdir/index.html" should contain 'src="../javascripts/application-1d8d5276.js"'
+    And the file "subdir/index.html" should contain 'href="../stylesheets/site-ed8c2d12.css"'
+    And the file "subdir/index.html" should contain 'src="../javascripts/application-df677242.js"'
     And the file "subdir/index.html" should contain 'src="../images/100px-5fd6fb90.jpg"'
-    And the file "other/index.html" should contain 'href="../stylesheets/site-50eaa978.css"'
-    And the file "other/index.html" should contain 'src="../javascripts/application-1d8d5276.js"'
+    And the file "other/index.html" should contain 'href="../stylesheets/site-ed8c2d12.css"'
+    And the file "other/index.html" should contain 'src="../javascripts/application-df677242.js"'
     And the file "other/index.html" should contain 'src="../images/100px-5fd6fb90.jpg"'
     
   Scenario: Hashed assets work in preview server
     Given the Server is running at "asset-hash-app"
     When I go to "/"
-    Then I should see 'href="stylesheets/site-50eaa978.css"'
-    And I should see 'src="javascripts/application-1d8d5276.js"'
+    Then I should see 'href="stylesheets/site-ed8c2d12.css"'
+    And I should see 'src="javascripts/application-df677242.js"'
     And I should see 'src="images/100px-5fd6fb90.jpg"'
     When I go to "/subdir/"
-    Then I should see 'href="../stylesheets/site-50eaa978.css"'
-    And I should see 'src="../javascripts/application-1d8d5276.js"'
+    Then I should see 'href="../stylesheets/site-ed8c2d12.css"'
+    And I should see 'src="../javascripts/application-df677242.js"'
     And I should see 'src="../images/100px-5fd6fb90.jpg"'
     When I go to "/other/"
-    Then I should see 'href="../stylesheets/site-50eaa978.css"'
-    And I should see 'src="../javascripts/application-1d8d5276.js"'
+    Then I should see 'href="../stylesheets/site-ed8c2d12.css"'
+    And I should see 'src="../javascripts/application-df677242.js"'
     And I should see 'src="../images/100px-5fd6fb90.jpg"'
-    When I go to "/javascripts/application-1d8d5276.js"
+    When I go to "/javascripts/application-df677242.js"
     Then I should see "img.src = '/images/100px-5fd6fb90.jpg'"
-    When I go to "/stylesheets/site-50eaa978.css"
+    When I go to "/stylesheets/site-ed8c2d12.css"
     Then I should see "background-image: url('../images/100px-5fd6fb90.jpg')"
 
   Scenario: Enabling an asset host still produces hashed files and references  
     Given the Server is running at "asset-hash-host-app"
     When I go to "/"
-    Then I should see 'href="http://middlemanapp.com/stylesheets/site-171eb3c0.css"'
+    Then I should see 'href="http://middlemanapp.com/stylesheets/site-e5a31a3e.css"'
     And I should see 'src="http://middlemanapp.com/images/100px-5fd6fb90.jpg"'
     When I go to "/subdir/"
-    Then I should see 'href="http://middlemanapp.com/stylesheets/site-171eb3c0.css"'
+    Then I should see 'href="http://middlemanapp.com/stylesheets/site-e5a31a3e.css"'
     And I should see 'src="http://middlemanapp.com/images/100px-5fd6fb90.jpg"'
     When I go to "/other/"
-    Then I should see 'href="http://middlemanapp.com/stylesheets/site-171eb3c0.css"'
+    Then I should see 'href="http://middlemanapp.com/stylesheets/site-e5a31a3e.css"'
     And I should see 'src="http://middlemanapp.com/images/100px-5fd6fb90.jpg"'
     # Asset helpers don't appear to work from Compass right now
-    # When I go to "/stylesheets/site-171eb3c0.css"
+    # When I go to "/stylesheets/site-e5a31a3e.css"
     # Then I should see "background-image: url('http://middlemanapp.com/images/100px-5fd6fb90.jpg')"
 
   Scenario: The asset hash should change when a SASS partial changes
@@ -73,14 +73,14 @@ Feature: Assets get a file hash appended to their and references to them are upd
         font-size: 14px
       """
     When I go to "/partials/"
-    Then I should see 'href="../stylesheets/uses_partials-423a00f7.css'
+    Then I should see 'href="../stylesheets/uses_partials-8b948098.css'
     And the file "source/stylesheets/_partial.sass" has the contents
       """
       body
         font-size: 18px !important
       """
     When I go to "/partials/"
-    Then I should see 'href="../stylesheets/uses_partials-e8c3d4eb.css'
+    Then I should see 'href="../stylesheets/uses_partials-1f9f0ed2.css'
 
   Scenario: The asset hash should change when a Javascript partial changes
     Given the Server is running at "asset-hash-app"
@@ -89,14 +89,14 @@ Feature: Assets get a file hash appended to their and references to them are upd
       function sprockets_sub_function() { }
       """
     When I go to "/partials/"
-    Then I should see 'src="../javascripts/sprockets_base-095c3f3f.js'
-    When I go to "/javascripts/sprockets_base-095c3f3f.js"
+    Then I should see 'src="../javascripts/sprockets_base-0252a861.js'
+    When I go to "/javascripts/sprockets_base-0252a861.js"
     Then I should see "sprockets_sub_function"
     And the file "source/javascripts/sprockets_sub.js" has the contents
       """
       function sprockets_sub2_function() { }
       """
     When I go to "/partials/"
-    Then I should see 'src="../javascripts/sprockets_base-095c3f3f.js'
-    When I go to "/javascripts/sprockets_base-095c3f3f.js"
+    Then I should see 'src="../javascripts/sprockets_base-5121d891.js'
+    When I go to "/javascripts/sprockets_base-5121d891.js"
     Then I should see "sprockets_sub2_function"


### PR DESCRIPTION
This PR complements [#641 in middleman-more](https://github.com/middleman/middleman/pull/641), updating the hashes of existing tests. It changes the last test to actually expect different hashes whenever a Javascript dependency is updated. This has been implemented in the linked pull request.
