### PR TITLE
Set current_path from within Sprockets' context.

### DIFF
--- a/lib/middleman-sprockets/extension.rb
+++ b/lib/middleman-sprockets/extension.rb
@@ -76,10 +76,20 @@ module Middleman::Sprockets
 
       # Make the app context available to Sprockets
       context_class.send(:define_method, :app) { app }
+
       context_class.class_eval do
+        # Find the Middleman-compatible version of this file's path
+        def mm_path
+          @mm_path ||= app.sitemap.file_to_path(pathname.to_s)
+        end
+
         def method_missing(*args)
           name = args.first
           if app.respond_to?(name)
+            # Set the middleman application current path, since it won't
+            # be set if the request came in through Sprockets and helpers
+            # won't work without it.
+            app.current_path = mm_path unless app.current_path
             app.send(*args)
           else
             super


### PR DESCRIPTION
All requests to /stylesheets and /javascripts are handled by Sprockets
exclusively. This means a file like /stylesheets/main.css.erb has its
ERb processing handled by Sprockets, not Middleman. We have a method_missing
that forwards references to helpers to the Middleman application, but
current_path wasn't being set because those requests weren't going through
Middleman's endpoint. This change has the Sprockets context explicitly
set current_path to the asset's path before forwarding helper requests
on to Middleman, meaning things that use current_path/current_resource
like relative_assets now have the info they need to work.

Fixes middleman/middleman#764 and middleman/middleman#731.
