### PR TITLE
Add an in-memory cache for Sprockets assets.

### DIFF
--- a/lib/middleman-sprockets/extension.rb
+++ b/lib/middleman-sprockets/extension.rb
@@ -75,6 +75,9 @@ module Middleman::Sprockets
       @app = app
       super app.source_dir
 
+      # By default, sprockets has no cache! Give it an in-memory one using a Hash
+      @cache = {}
+
       # Make the app context available to Sprockets
       context_class.send(:define_method, :app) { app }
 


### PR DESCRIPTION
For some reason Sprockets defaults to no cache, so any change to an asset
requires rebuilding all assets. This really hurts for big single-page JS apps.
Adding a hash-based cache fixes that. This was figured out by @jvaill, thanks!
Fixes middleman/middleman#734.
