### PR TITLE
Add sprockets-helpers to the list of gem dependencies.

### DIFF
--- a/middleman-sprockets.gemspec
+++ b/middleman-sprockets.gemspec
@@ -17,8 +17,9 @@ Gem::Specification.new do |s|
   s.files         = `git ls-files -z`.split("\0")
   s.test_files    = `git ls-files -z -- {fixtures,features}/*`.split("\0")
   s.require_paths = ["lib"]
-  
+
   s.add_dependency("middleman-core", [">= 3.0.11"])
   s.add_dependency("sprockets", ["~> 2.1"])
   s.add_dependency("sprockets-sass", ["~> 1.0.0"])
+  s.add_dependency("sprockets-helpers", ["~> 1.0.0"])
 end


### PR DESCRIPTION
The [sprockets-sass README](https://github.com/petebrowne/sprockets-sass/blob/master/README.md) mentions using this gem for asset paths, and adding it magically fixes the relative_assets-related issue #32.

I spent a big chunk of the evening digging through compass and sprockets trying to figure out #32, and I ran out of steam after I found sprockets-sass and sprockets-helpers. So I didn't look into removing any duplicate helpers from middleman-sprockets, and I didn't add tests (using `Gemfile-3.1`, I couldn't get the current tests to pass).

I submitted this so others in my situation can benefit from the quick fix, and I'll be happy to iterate on this pull request based on feedback.

Thank you so much for middleman! After a week of usage, it's still rocking my world!
