### PR TITLE
Fix for :debug_assets

### DIFF
--- a/lib/middleman-sprockets/extension.rb
+++ b/lib/middleman-sprockets/extension.rb
@@ -292,7 +292,7 @@ module Middleman::Sprockets
           dependencies_paths = sprockets[source].to_a.map do |dependency|
             # if sprockets sees "?body=1" it only gives back the body
             # of the script without the dependencies included
-            dependency.logical_path + "?body=1"
+            dependency.logical_path << "?body=1"
           end
 
           super(dependencies_paths, options)


### PR DESCRIPTION
When :debug_assets is on, prevent "?body=1" from being appended multiple times to a script tag. This will eventually cause a browser error because of the enormous URL.

Screenshot of the bug is attached.

![screenshot](https://f.cloud.github.com/assets/659307/508431/7704eb10-bd87-11e2-8182-5b39d05cecfd.png)
