### PR TITLE
use a file based cache like sprockets-rails

### DIFF
--- a/lib/middleman-sprockets/extension.rb
+++ b/lib/middleman-sprockets/extension.rb
@@ -84,8 +84,9 @@ module Middleman::Sprockets
 
       super app.source_dir
 
-      # By default, sprockets has no cache! Give it an in-memory one using a Hash
-      @cache = {}
+      # By default, sprockets has no cache! Give it a file-based cache so that
+      # the cache is persisted between sessions
+      @cache = ::Sprockets::Cache::FileStore.new(File.join app.root, '.cache')
 
       enhance_context_class!
 


### PR DESCRIPTION
This is especially useful for large javascript apps. It allows the cache to be persisted between sessions so that you aren't recompiling from scratch on every new run of `middleman server`. This change still allows for incremental recompilation during development, so it keeps the speed and loses the pain of rebooting middleman.
