### PR TITLE
Fix using SCRIPT_NAME when not mounted on root

### DIFF
--- a/lib/middleman-sprockets/environment.rb
+++ b/lib/middleman-sprockets/environment.rb
@@ -185,7 +185,8 @@ module Middleman
 
       def call(env)
         # Set the app current path based on the full URL so that helpers work
-        request_path = URI.decode(File.join(env['SCRIPT_NAME'], env['PATH_INFO']))
+        script_name = env['SCRIPT_NAME'].gsub(/^#{@app.config[:http_prefix]}/i, '') if @app.config[:http_prefix]
+        request_path = URI.decode(File.join(script_name, env['PATH_INFO']))
         if request_path.respond_to? :force_encoding
           request_path.force_encoding('UTF-8')
         end

--- a/lib/middleman-sprockets/environment.rb
+++ b/lib/middleman-sprockets/environment.rb
@@ -185,7 +185,8 @@ module Middleman
 
       def call(env)
         # Set the app current path based on the full URL so that helpers work
-        script_name = env['SCRIPT_NAME'].gsub(/^#{@app.config[:http_prefix]}/i, '') if @app.config[:http_prefix]
+        script_name = env['SCRIPT_NAME'].dup
+        script_name.gsub!(/^#{@app.config[:http_prefix]}/i, '') if @app.config[:http_prefix]
         request_path = URI.decode(File.join(script_name, env['PATH_INFO']))
         if request_path.respond_to? :force_encoding
           request_path.force_encoding('UTF-8')


### PR DESCRIPTION
See middleman/middleman#1394. This fixes Middleman assets when not mounted on root. Requires config[:http_prefix] to be set.