### PR TITLE
Add Woff2 to font extensions list

### DIFF
--- a/lib/middleman-sprockets/asset.rb
+++ b/lib/middleman-sprockets/asset.rb
@@ -108,7 +108,7 @@ module Middleman
       alias_method :is_in_fonts_directory?, :is_font_by_path?
 
       def is_font_by_extension?
-        has_extname?(*%w(.ttf .woff .eot .otf .svg .svgz))
+        has_extname?(*%w(.ttf .woff .woff2 .eot .otf .svg .svgz))
       end
 
       def font_paths


### PR DESCRIPTION
As part of the addition to middleman core [here](https://github.com/middleman/middleman/pull/1445) I've added the woff2 extension to the list of font-specific extensions