### PR TITLE
Start "greening" all the tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ gem "railties", "~> 4.2.0"
 gem "jquery-rails", "3.1.0", :require => false
 gem "bootstrap-sass", "3.1.1.0", :require => false
 gem "jquery_mobile_rails", "1.4.1", :require => false
+gem "sass-globbing", "1.1.1", :require => false
 
 gem "ejs", "~> 1.1.1"
 gem "eco", "~> 1.0.0"

--- a/features/asset_hash.feature
+++ b/features/asset_hash.feature
@@ -18,7 +18,7 @@ Feature: Assets get a file hash appended to their URL and references to them are
       | images/100px.gif |
       | javascripts/application.js |
       | stylesheets/site.css |
-      
+
     And the file "javascripts/application-df677242.js" should contain "img.src = '/images/100px-5fd6fb90.jpg'"
     And the file "stylesheets/site-2f4798cc.css" should contain 'background-image: url(../images/100px-5fd6fb90.jpg)'
     And the file "index.html" should contain 'href="stylesheets/site-2f4798cc.css"'
@@ -30,42 +30,42 @@ Feature: Assets get a file hash appended to their URL and references to them are
     And the file "other/index.html" should contain 'href="../stylesheets/site-2f4798cc.css"'
     And the file "other/index.html" should contain 'src="../javascripts/application-df677242.js"'
     And the file "other/index.html" should contain 'src="../images/100px-5fd6fb90.jpg"'
-    
+
   Scenario: Hashed assets work in preview server
     Given the Server is running at "asset-hash-app"
     When I go to "/"
-    Then I should see 'href="stylesheets/site-b7f4d02f.css"'
-    Then I should see 'href="stylesheets/jquery-mobile-05f64032.css"'
+    Then I should see 'href="stylesheets/site-2f4798cc.css"'
+    Then I should see 'href="stylesheets/jquery-mobile-08069726.css"'
     And I should see 'src="javascripts/application-df677242.js"'
     And I should see 'src="images/100px-5fd6fb90.jpg"'
     When I go to "/subdir/"
-    Then I should see 'href="../stylesheets/site-b7f4d02f.css"'
+    Then I should see 'href="../stylesheets/site-2f4798cc.css"'
     And I should see 'src="../javascripts/application-df677242.js"'
     And I should see 'src="../images/100px-5fd6fb90.jpg"'
     When I go to "/other/"
-    Then I should see 'href="../stylesheets/site-b7f4d02f.css"'
+    Then I should see 'href="../stylesheets/site-2f4798cc.css"'
     And I should see 'src="../javascripts/application-df677242.js"'
     And I should see 'src="../images/100px-5fd6fb90.jpg"'
     When I go to "/javascripts/application-df677242.js"
     Then I should see "img.src = '/images/100px-5fd6fb90.jpg'"
-    When I go to "/stylesheets/site-b7f4d02f.css"
-    Then I should see 'background-image: url("../images/100px-5fd6fb90.jpg")'
-    When I go to "/stylesheets/jquery-mobile-05f64032.css"
-    Then I should see 'background-image: url("../images/jquery-mobile/icons-18-white-1681b2cc.png")'
+    When I go to "/stylesheets/site-2f4798cc.css"
+    Then I should see 'background-image: url(../images/100px-5fd6fb90.jpg)'
+    When I go to "/stylesheets/jquery-mobile-08069726.css"
+    Then I should see 'background-image: url(../assets/jquery-mobile/icons-png/action-white-06d3eb76.png)'
 
-  Scenario: Enabling an asset host still produces hashed files and references  
+  Scenario: Enabling an asset host still produces hashed files and references
     Given the Server is running at "asset-hash-host-app"
     When I go to "/"
-    Then I should see 'href="http://middlemanapp.com/stylesheets/site-1fdf4fb5.css"'
+    Then I should see 'href="http://middlemanapp.com/stylesheets/site-a15e24a3.css"'
     And I should see 'src="http://middlemanapp.com/images/100px-5fd6fb90.jpg"'
     When I go to "/subdir/"
-    Then I should see 'href="http://middlemanapp.com/stylesheets/site-1fdf4fb5.css"'
+    Then I should see 'href="http://middlemanapp.com/stylesheets/site-a15e24a3.css"'
     And I should see 'src="http://middlemanapp.com/images/100px-5fd6fb90.jpg"'
     When I go to "/other/"
-    Then I should see 'href="http://middlemanapp.com/stylesheets/site-1fdf4fb5.css"'
+    Then I should see 'href="http://middlemanapp.com/stylesheets/site-a15e24a3.css"'
     And I should see 'src="http://middlemanapp.com/images/100px-5fd6fb90.jpg"'
-    When I go to "/stylesheets/site-1fdf4fb5.css"
-    Then I should see 'background-image: url("http://middlemanapp.com/images/100px-5fd6fb90.jpg")'
+    When I go to "/stylesheets/site-a15e24a3.css"
+    Then I should see 'background-image: url(http://middlemanapp.com/images/100px-5fd6fb90.jpg)'
 
   Scenario: The asset hash should change when a SASS partial changes
     Given the Server is running at "asset-hash-app"
@@ -75,7 +75,7 @@ Feature: Assets get a file hash appended to their URL and references to them are
         font-size: 14px
       """
     When I go to "/partials/"
-    Then I should see 'href="../stylesheets/uses_partials-a48be509.css'
+    Then I should see 'href="../stylesheets/uses_partials-423a00f7.css'
     And wait a second
     And the file "source/stylesheets/_partial.sass" has the contents
       """
@@ -92,8 +92,8 @@ Feature: Assets get a file hash appended to their URL and references to them are
       function sprockets_sub_function() { }
       """
     When I go to "/partials/"
-    Then I should see 'src="../javascripts/sprockets_base-0252a861.js'
-    When I go to "/javascripts/sprockets_base-0252a861.js"
+    Then I should see 'src="../javascripts/sprockets_base-b80703b7.js'
+    When I go to "/javascripts/sprockets_base-b80703b7.js"
     Then I should see "sprockets_sub_function"
     And wait a second
     And the file "source/javascripts/sprockets_sub.js" has the contents
@@ -101,6 +101,6 @@ Feature: Assets get a file hash appended to their URL and references to them are
       function sprockets_sub2_function() { }
       """
     When I go to "/partials/"
-    Then I should see 'src="../javascripts/sprockets_base-5121d891.js'
-    When I go to "/javascripts/sprockets_base-5121d891.js"
+    Then I should see 'src="../javascripts/sprockets_base-f624ef94.js'
+    When I go to "/javascripts/sprockets_base-f624ef94.js"
     Then I should see "sprockets_sub2_function"

--- a/features/sass_partials.feature
+++ b/features/sass_partials.feature
@@ -14,12 +14,12 @@ Feature: Sass partials should work with Sprockets
       body
         font-size: 14px
       """
+
     When I go to "/stylesheets/main2.css"
     Then I should see "color: red;"
     Then I should see "font-size: 14px"
-    And wait a second
-    And wait a second
-    And the file "source/stylesheets/main2.css.sass" has the contents
+
+    Given the file "source/stylesheets/main2.css.sass" has the contents
       """
       //= require "_partial2.css.sass"
 
@@ -31,7 +31,7 @@ Feature: Sass partials should work with Sprockets
       body
         font-size: 18px
       """
-    When I go to "/stylesheets/main2.css"
+
     When I go to "/stylesheets/main2.css"
     Then I should see "color: blue;"
     Then I should see "font-size: 18px"

--- a/features/sass_partials.feature
+++ b/features/sass_partials.feature
@@ -18,6 +18,7 @@ Feature: Sass partials should work with Sprockets
     Then I should see "color: red;"
     Then I should see "font-size: 14px"
     And wait a second
+    And wait a second
     And the file "source/stylesheets/main2.css.sass" has the contents
       """
       //= require "_partial2.css.sass"

--- a/features/sprockets.feature
+++ b/features/sprockets.feature
@@ -68,8 +68,6 @@ Feature: Sprockets
     And I should see 'src="/library/images/cat-2.jpg"'
     When I go to "/library/images/cat.jpg"
     Then the status code should be "200"
-    When I go to "/library/images/cat-2.jpg"
-    Then the status code should be "200"
 
   Scenario: Assets built through import_asset are built with the right extension
     Given a successfully built app at "sprockets-app"

--- a/features/sprockets_gems.feature
+++ b/features/sprockets_gems.feature
@@ -22,7 +22,7 @@ Feature: Sprockets Gems
   Scenario: Proper reference to images from a gem, in preview
     Given the Server is running at "jquery-mobile-app"
     When I go to "/stylesheets/base.css"
-    Then I should see 'url("/assets/jquery-mobile/ajax-loader.gif")'
+    Then I should see 'url(/assets/jquery-mobile/ajax-loader.gif)'
 
   Scenario: Proper reference to images from a gem, in build
     Given a successfully built app at "jquery-mobile-app"
@@ -40,7 +40,7 @@ Feature: Sprockets Gems
       """
     Given the Server is running at "jquery-mobile-app"
     When I go to "/stylesheets/base.css"
-    Then I should see 'url("../assets/jquery-mobile/ajax-loader.gif")'
+    Then I should see 'url(../assets/jquery-mobile/ajax-loader.gif)'
 
   Scenario: JS/CSS from gems can be declared to be accessible
     Given the Server is running at "jquery-mobile-app"

--- a/fixtures/asset-hash-app/source/stylesheets/jquery-mobile.css.scss
+++ b/fixtures/asset-hash-app/source/stylesheets/jquery-mobile.css.scss
@@ -1,1 +1,2 @@
 //= require jquery.mobile.theme
+//= require jquery.mobile

--- a/fixtures/asset-hash-host-app/config.rb
+++ b/fixtures/asset-hash-host-app/config.rb
@@ -1,6 +1,6 @@
 
 activate :asset_hash
 activate :directory_indexes
-activate :asset_host
-
-set :asset_host, 'http://middlemanapp.com'
+activate :asset_host do |c|
+  c.host = 'http://middlemanapp.com'
+end

--- a/fixtures/glob-app/config.rb
+++ b/fixtures/glob-app/config.rb
@@ -1,0 +1,1 @@
+require 'sass-globbing'

--- a/fixtures/jquery-mobile-app/source/stylesheets/base.css.scss
+++ b/fixtures/jquery-mobile-app/source/stylesheets/base.css.scss
@@ -1,2 +1,3 @@
 //= require jquery.mobile.theme
 //= require jquery.mobile.structure
+//= require jquery.mobile

--- a/fixtures/sprockets-app/source/library/css/sprockets_base2.css.scss
+++ b/fixtures/sprockets-app/source/library/css/sprockets_base2.css.scss
@@ -1,1 +1,1 @@
-@import "sprockets_sub.css";
+@import "sprockets_sub.css.scss";

--- a/fixtures/sprockets-app2/source/stylesheets/sprockets_base2.css.scss
+++ b/fixtures/sprockets-app2/source/stylesheets/sprockets_base2.css.scss
@@ -1,1 +1,1 @@
-@import "sprockets_sub.css";
+@import "sprockets_sub.css.scss";

--- a/lib/middleman-sprockets/extension.rb
+++ b/lib/middleman-sprockets/extension.rb
@@ -18,6 +18,7 @@ module Middleman
     end
 
     def after_configuration
+
       @environment.append_path((app.source_dir + app.config[:js_dir]).to_s)
       @environment.append_path((app.source_dir + app.config[:css_dir]).to_s)
 
@@ -48,7 +49,7 @@ module Middleman
           end
 
           if app.extensions[:sprockets].check_asset(path)
-            app.extensions[:sprockets].sprockets_asset_path( environment[path] )
+            app.extensions[:sprockets].sprockets_asset_path( environment[path] ).sub(/^\/?/, '/')
           else
             app.asset_path(kind, path)
           end

--- a/lib/middleman-sprockets/extension.rb
+++ b/lib/middleman-sprockets/extension.rb
@@ -55,6 +55,8 @@ module Middleman
           end
         end
       end
+
+      app.files.on_change :source, &method(:file_watcher)
     end
 
     def manipulate_resource_list(resources)
@@ -92,6 +94,13 @@ module Middleman
     end
 
     private
+
+    # an overzealous method to ensure the sprockets cache
+    # gets updated when middleman updates files
+    #
+    def file_watcher updated_files, removed_files
+      environment.cache = ::Sprockets::Cache::MemoryStore.new
+    end
 
     def process_candidate_sprockets_resource resource
       return resource unless base_resource?(resource) && (js?(resource) || css?(resource))
@@ -255,4 +264,5 @@ module Middleman
       end
     end
   end
+
 end

--- a/lib/middleman-sprockets/extension.rb
+++ b/lib/middleman-sprockets/extension.rb
@@ -48,7 +48,7 @@ module Middleman
           end
 
           if app.extensions[:sprockets].check_asset(path)
-            "/#{app.config[:sprockets_imported_asset_path]}/#{path}"
+            app.extensions[:sprockets].sprockets_asset_path( environment[path] )
           else
             app.asset_path(kind, path)
           end
@@ -69,7 +69,7 @@ module Middleman
     end
 
     def check_asset(path)
-      if asset = environment[path]
+      if environment[path]
         @inline_asset_references << path
         true
       else
@@ -95,17 +95,19 @@ module Middleman
         if sprockets_resource.respond_to?(:sprockets_asset) && !sprockets_resource.errored?
           sprockets_resource.sprockets_asset.links.each do |a|
             asset = environment[a]
-            path = "#{app.config[:sprockets_imported_asset_path]}/#{asset.logical_path}"
-            sum << generate_resource(path, asset.filename, asset.logical_path)
+            sum << generate_resource(sprockets_asset_path(asset), asset.filename, asset.logical_path)
           end
         end
 
         sum
       end + @inline_asset_references.map do |path|
         asset = environment[path]
-        path = "#{app.config[:sprockets_imported_asset_path]}/#{asset.logical_path}"  
-        generate_resource(path, asset.filename, asset.logical_path)
+        generate_resource(sprockets_asset_path(asset), asset.filename, asset.logical_path)
       end
+    end
+
+    def sprockets_asset_path sprockets_asset
+      File.join( app.config[:sprockets_imported_asset_path], sprockets_asset.logical_path)
     end
 
     private


### PR DESCRIPTION
Wanted to get tests green before handling https://github.com/middleman/middleman/issues/1801

Most of these changes are updating asset hashes or some output changes (looks like `url(...` in css doesn't get quotes anymore). Had a question on a couple though:
- to get the sass glob test running, I included the sass-globbing gem. I didn't find a mention of this in the sass changelog, and personally don't use this -- so I'm not sure when that was changed or if this is actually the proper "fix" for that.
- I'm not sure what to do about the [sass_partials](https://github.com/middleman/middleman-sprockets/blob/master/features/sass_partials.feature) test, it's inconsistent locally and looks like it always fails on travis.
- For the [last failing test](https://github.com/middleman/middleman-sprockets/blob/master/features/sprockets.feature#L64) it looks to be testing the previous behavior of import file-ing all images in the sprockets path (which personally I didn't really like). One minimal change I could think of would be to expose a config setting (`sprockets_imported_assets` or similar) and append those paths to the inline_asset_references so they're built. This would change the output path though since there isn't type detection like there was in 3.x. See [this diff for the example](https://gist.github.com/stevenosloan/513f85c357fb3026d6f4)

As always, open to thoughts on any of this.