### PR TITLE
Limit handling of files to specified outputs types & usable templating langs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem 'sass-globbing',       '1.1.1',   require: false
 gem 'ejs',    '~> 1.1.1'
 gem 'eco',    '~> 1.0.0'
 gem 'erubis', '~> 2.7.0'
+gem 'haml',   '~> 4.0', require: false
 
 # Code Quality
 group :test do

--- a/features/excluded_file_extensions.feature
+++ b/features/excluded_file_extensions.feature
@@ -1,0 +1,31 @@
+Feature: Files with unhandled file extensions are ignored
+
+  Scenario: HTML & Dotfiles in css_dir or js_dir are handled by middleman only
+    Given a fixture app "sprockets-app"
+    And a file named "source/library/js/.jslintrc" with:
+      """
+      {"bitwise":true}
+      """
+    And a file named "source/library/js/index.html.erb" with:
+      """
+      <h1><%= current_resource.url %></h1>
+      """
+    And the Server is running
+
+    When I go to "/library/js/.jslintrc"
+    Then I should see '{"bitwise":true}'
+
+    When I go to "/library/js"
+    Then I should see "<h1>/library/js/</h1>"
+
+  Scenario: Files with Tilt templates, but not supported by sprockets, are handled properly
+    Given a fixture app "sprockets-app"
+    And a file named "source/library/js/index.js.haml" with:
+      """
+      :plain
+        alert('why haml?');
+      """
+    And the Server is running
+
+    When I go to "/library/js/index.js"
+    Then I should see "alert('why haml?');"


### PR DESCRIPTION
Adds a check for `processable?` that checks against:
- output types that we select (for now .css & .js)
- input types that sprockets can handle

This should alleviate issues where html files, dot files, or template types that sprockets doesn’t support (less for example) throw errors while middleman itself can handle them just fine. We might start to see reports of sprockets *not* handling files as user would expect (.less for example), so it’s something to be aware of.

This should close #90, #85, and cover the html case of #87.

@eaigner, @morgoth, @Aetherus if y'all can give this a shot that'd be great. To test, in your Gemfile:

```ruby
gem 'middleman-sprockets', github: 'stevenosloan/middleman-sprockets', branch: 'filter_out_unhandled_types'
```