### PR TITLE
respect assets that have been ignored

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -20,11 +20,7 @@ Cucumber::Rake::Task.new(:cucumber, 'Run features that should pass') do |t|
     exempt_tags.push '--tags ~@sprockets4'
   end
 
-  if ENV['SKIP_ASSET_HASH'] == 'true'
-    exempt_tags.push '--tags ~@asset_hash'
-  end
-
-
+  exempt_tags.push '--tags ~@asset_hash' if ENV['SKIP_ASSET_HASH'] == 'true'
   t.cucumber_opts = "--color #{exempt_tags.join(' ')} --strict"
 end
 

--- a/features/test_cases/ignore_directive_is_respected.feature
+++ b/features/test_cases/ignore_directive_is_respected.feature
@@ -1,0 +1,90 @@
+Feature: Files that match ignore directives are not built
+
+  Scenario: Sprockets asset that matches an ignore isn't built # but does link assets
+    Given a fixture app "base-app"
+    And a file named "config.rb" with:
+      """
+      activate :sprockets
+      ignore "javascripts/vendor/*"
+      """
+    And a file named "source/javascripts/vendor/site.js" with:
+      """
+      console.log('vendor/site.js');
+      """
+    And a file named "source/javascripts/site.js" with:
+      """
+      //= require 'vendor/site'
+      """
+    And the Server is running
+
+    When I go to "/javascripts/vendor/site.js"
+    Then the status code should be "404"
+
+    When I go to "/javascripts/site.js"
+    Then the status code should be "200"
+    And I should see "console.log('vendor/site.js');"
+
+    And a built app
+    Then the following files should not exist:
+      | build/javascripts/vendor/site.js |
+    Then the following files should exist:
+      | build/javascripts/site.js |
+
+  Scenario: Sprockets assets that are ignored are processed for links
+    Given a fixture app "base-app"
+    And a file named "config.rb" with:
+      """
+      activate :sprockets
+      sprockets.append_path File.join(root, 'vendor')
+      ignore "javascripts/manifest.js"
+      """
+    And a file named "vendor/linked.js" with:
+      """
+      console.log('vendor/linked.js');
+      """
+    And a file named "source/javascripts/manifest.js" with:
+      """
+      //= link 'linked'
+      """
+    And the Server is running
+
+    When I go to "/javascripts/manifest.js"
+    Then the status code should be "404"
+
+    When I go to "/assets/linked.js"
+    Then the status code should be "200"
+    And I should see "console.log('vendor/linked.js');"
+
+    And a built app
+    Then the following files should not exist:
+      | build/javascripts/manifest.js |
+    Then the following files should exist:
+      | build/assets/linked.js |
+
+
+  Scenario: Linked assets that match don't build
+    Given a fixture app "base-app"
+    And a file named "config.rb" with:
+      """
+      activate :sprockets
+      sprockets.append_path File.join(root, 'vendor')
+      ignore "assets/vendor/*"
+      """
+    And a file named "vendor/vendor/site.js" with:
+      """
+      console.log('vendor/site.js');
+      """
+    And a file named "source/javascripts/manifest.js" with:
+      """
+      //= link 'vendor/site'
+      """
+    And the Server is running
+
+    When I go to "/assets/vendor/site.js"
+    Then the status code should be "404"
+
+    And a built app
+    Then the following files should exist:
+      | build/javascripts/manifest.js |
+    Then the following files should not exist:
+      | build/assets/vendor/site.js |

--- a/lib/middleman-sprockets/extension.rb
+++ b/lib/middleman-sprockets/extension.rb
@@ -85,12 +85,8 @@ module Middleman
       end
     end
 
-    def base_resource? r
-      r.class.ancestors.first == ::Middleman::Sitemap::Resource
-    end
-
     def processible? r
-      base_resource?(r) && interface.processible?(r.source_file)
+      !r.is_a?(SprocketsResource) && interface.processible?(r.source_file)
     end
 
     def js? r

--- a/lib/middleman-sprockets/extension.rb
+++ b/lib/middleman-sprockets/extension.rb
@@ -90,7 +90,11 @@ module Middleman
         generate_resource(sprockets_asset_path(asset), asset.filename, asset.logical_path)
       end
 
-      app.extensions[:sitemap_ignore].manipulate_resource_list sprockets_resources + linked_resources
+      if app.extensions[:sitemap_ignore].respond_to?(:manipulate_resource_list)
+        app.extensions[:sitemap_ignore].manipulate_resource_list sprockets_resources + linked_resources
+      else
+        sprockets_resources + linked_resources
+      end
     end
 
     def base_resource? r

--- a/lib/middleman-sprockets/interface.rb
+++ b/lib/middleman-sprockets/interface.rb
@@ -11,7 +11,6 @@ module Middleman
         setup!
       end
 
-
       module Sprockets4
         def setup!
           acceptable_mimes = options[:supported_output_extensions].map do |ext|
@@ -31,9 +30,7 @@ module Middleman
           file_ext, _mime = ::Sprockets::PathUtils.match_path_extname(filename, environment.config[:mime_exts])
           extensions.include?(file_ext)
         end
-
       end
-
 
       module Sprockets3
         def setup!
@@ -51,7 +48,6 @@ module Middleman
       else
         include Sprockets3
       end
-
     end
   end
 end

--- a/lib/middleman-sprockets/resource.rb
+++ b/lib/middleman-sprockets/resource.rb
@@ -55,7 +55,7 @@ module Middleman
             default_response
           end
         end
-        alias_method :to_s, :source
+        alias to_s source
 
         private
 
@@ -65,7 +65,7 @@ module Middleman
 
           def js_response
             file, line = @error.backtrace[0].split(':')
-            err = "#{@error.class.name}: #{@error.message}\n" +
+            err = "#{@error.class.name}: #{@error.message}\n" \
                   "  on line #{line} of #{file})"
 
             "throw Error(#{err.inspect})"


### PR DESCRIPTION
@tdreyno here's a partial fix for #96 / https://github.com/middleman/middleman/issues/1789 -- I realized I'm not quite sure what the correct behavior for linked assets is though.

With this implementation -- ignored assets are never processed, so if they had linked assets they aren't linked. But since we're inserting linked assets after the ignore descriptors have run -- they don't get ignored. I feel like this is the "least surprising" option, but leaves me with two questions:
- should we process ignored assets for links
- should linked assets be ignorable (I'm not sure why you would do this, and it could cause issues as the link indicates a dependency)

look forward to your thoughts