### PR TITLE
Allow ignoring paths from imported gems.

### DIFF
--- a/lib/middleman-sprockets/config_only_environment.rb
+++ b/lib/middleman-sprockets/config_only_environment.rb
@@ -9,11 +9,13 @@ module Middleman
       attr_reader :imported_assets
       attr_reader :appended_paths
       attr_reader :prepended_paths
+      attr_reader :ignored_paths
 
       def initialize(options={})
         @imported_assets = []
         @appended_paths = []
         @prepended_paths = []
+        @ignored_paths = []
       end
 
       def method_missing?(method)
@@ -44,6 +46,10 @@ module Middleman
 
       def prepend_path(path)
         @prepended_paths << path
+      end
+
+      def ignore_path(path)
+        @ignored_paths << path
       end
     end
   end

--- a/lib/middleman-sprockets/extension.rb
+++ b/lib/middleman-sprockets/extension.rb
@@ -75,6 +75,7 @@ module Middleman
       @environment = ::Middleman::Sprockets::Environment.new(app, :debug_assets => debug_assets)
       config_environment.apply_to_environment(@environment)
 
+      @config_environment = config_environment
       append_paths_from_gems
       import_images_and_fonts_from_gems
 
@@ -146,6 +147,7 @@ module Middleman
     def import_images_and_fonts_from_gems
       environment.paths
           .reject { |p| p.start_with?(app.source_dir) }
+          .reject { |p| @config_environment.ignored_paths.any?{|r| r.match(p)}}
           .select { |p| p.end_with?('images') || p.end_with?('fonts') }
           .each do |load_path|
         environment.each_entry(load_path) do |path|


### PR DESCRIPTION
Don't know if anyone else needs this, but I came across a situation where I wanted to use a gem for the library functions it provides, but didn't want middleman automatically importing the assets. I added an `ignore_path` config setting so I could bypass loading the assets from that gem.

**E.g.:**

- Gem file:
```
gem "gem_with_assets_i_dont_want"
```

- config.rb
```
sprockets.ignore_path = /gem_with_assets_i_dont_want/
```