### PR TITLE
imported_asset_path_processor for issue #107

### DIFF
--- a/features/test_cases/imported_asset_processor.feature
+++ b/features/test_cases/imported_asset_processor.feature
@@ -1,0 +1,88 @@
+Feature: Imported assets can be placed in paths determined by a processor
+
+  Background:
+    Given a fixture app "base-app"
+    And a file named "config.rb" with:
+      """
+      activate :sprockets do |config|
+        config.imported_asset_path_processor = ->(asset) {
+          if asset.logical_path =~ /\.js$/
+            File.join('vendor-js', asset.logical_path)
+          elsif asset.logical_path =~ /^images\//
+            'vendor-' + asset.logical_path
+          elsif asset.logical_path =~ /^fonts\//
+            '3rd-party-' + asset.logical_path
+          else
+            asset.logical_path
+          end
+        }
+      end
+      sprockets.append_path File.join(root, 'vendor')
+      """
+    And a file named "vendor/fonts/webfont-vendor.svg" with:
+      """
+      """
+    And a file named "vendor/fonts/webfont-vendor.svg.gz" with:
+      """
+      """
+    And a file named "vendor/fonts/webfont-vendor.ttf.gz" with:
+      """
+      """
+    And a file named "source/fonts/webfont-source.svg" with:
+      """
+      """
+    And a file named "source/fonts/webfont-source.svg.gz" with:
+      """
+      """
+    And a file named "source/fonts/webfont-source.ttf.gz" with:
+      """
+      """
+    And a file named "vendor/images/drawing-vendor.svg" with:
+      """
+      """
+    And a file named "source/images/drawing-source.svg" with:
+      """
+      """
+    And a file named "vendor/images/extensions-source.svg.gz" with:
+      """
+      """
+    And a file named "vendor/images/extensions-source.min.js" with:
+      """
+      """
+    And a file named "vendor/images/extensions-source.asdf.asdf.min.js.asdf" with:
+      """
+      """
+
+
+  Scenario: Assets built by being linked are built with the right extension
+    Given a file named "source/stylesheets/manifest.css" with:
+      """
+      //= link 'fonts/webfont-vendor.svg'
+      //= link 'fonts/webfont-vendor.svg.gz'
+      //= link 'fonts/webfont-vendor.ttf.gz'
+      //= link 'images/drawing-vendor.svg'
+      //= link 'images/extensions-source.svg.gz'
+      //= link 'images/extensions-source.min.js'
+      //= link 'images/extensions-source.asdf.asdf.min.js.asdf'
+      """
+    And a successfully built app
+
+    When I cd to "build"
+    Then the following files should exist:
+      | 3rd-party-fonts/webfont-vendor.svg |
+      | 3rd-party-fonts/webfont-vendor.svg.gz |
+      | 3rd-party-fonts/webfont-vendor.ttf.gz |
+      | vendor-images/drawing-vendor.svg |
+      | vendor-images/extensions-source.svg.gz |
+      | vendor-images/extensions-source.asdf.asdf.min.js.asdf |
+      | vendor-js/images/extensions-source.min.js |
+
+  Scenario: Assets in source don't have their extensions mangled
+    Given a successfully built app
+
+    When I cd to "build"
+    Then the following files should exist:
+      | fonts/webfont-source.svg |
+      | fonts/webfont-source.svg.gz |
+      | fonts/webfont-source.ttf.gz |
+      | images/drawing-source.svg |

--- a/lib/middleman-sprockets/extension.rb
+++ b/lib/middleman-sprockets/extension.rb
@@ -16,9 +16,10 @@ module Middleman
       expose_to_config   sprockets: :environment
       expose_to_template sprockets: :environment
 
-      option :supported_output_extensions, ['.css', '.js'], 'Output extensions sprockets should process'
-      option :imported_asset_path,         'assets',        'Where under source imported assets should be placed.'
-      option :expose_middleman_helpers,    false,           'Whether to expose middleman helpers to sprockets.'
+      option :supported_output_extensions,   ['.css', '.js'], 'Output extensions sprockets should process'
+      option :imported_asset_path_processor, nil,             'Processor that determines where assets should be placed.'
+      option :imported_asset_path,           'assets',        'Where under source imported assets should be placed.'
+      option :expose_middleman_helpers,      false,           'Whether to expose middleman helpers to sprockets.'
 
       Contract ::Middleman::Application, Hash, Maybe[Proc] => Any
       def initialize app, options_hash={}, &block
@@ -119,7 +120,12 @@ module Middleman
 
       Contract ::Sprockets::Asset => String
       def sprockets_asset_path sprockets_asset
-        File.join(options[:imported_asset_path], sprockets_asset.logical_path)
+        unless options[:imported_asset_path_processor].nil?
+          return options[:imported_asset_path_processor].call(sprockets_asset)
+        end
+        path = [sprockets_asset.logical_path]
+        path.unshift(options[:imported_asset_path]) unless options[:imported_asset_path].nil?
+        File.join(path)
       end
 
       private


### PR DESCRIPTION
I have added `imported_asset_path_processor` config directive that will allow a user to decide where a linked asset should be placed (for issue #107).