### PR TITLE
Fix incompatibility with image_tag and link_to helpers

### DIFF
--- a/lib/middleman-sprockets/extension.rb
+++ b/lib/middleman-sprockets/extension.rb
@@ -75,11 +75,7 @@ module Middleman
 
       Contract String => Bool
       def check_asset path
-        if path.present? && environment[path]
-          true
-        else
-          false
-        end
+        path.present? && environment[path]
       end
 
       Contract ::Sprockets::Asset => String

--- a/lib/middleman-sprockets/extension.rb
+++ b/lib/middleman-sprockets/extension.rb
@@ -75,7 +75,7 @@ module Middleman
 
       Contract String => Bool
       def check_asset path
-        if environment[path]
+        if path.present? && environment[path]
           true
         else
           false


### PR DESCRIPTION
Hi,

With the following `Gemfile`:

```ruby
gem 'middleman', '~> 4.2'
gem 'middleman-autoprefixer', '~> 2.7'
gem 'middleman-sprockets'
gem 'font-awesome-sass', '~> 4.2.0'
gem 'bootstrap-sass', '~> 3.3.1'
gem 'jquery-middleman'
```

there was an issue with `link_to` and `image_tag` helpers. I tracked the bug back to this method in `middleman-sprockets` where basically the `path` was `""`.